### PR TITLE
[0.1.0] IPR-2 swagger설정 및 공통 ApiResponse 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,13 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flex/interpre/global/config/SwaggerConfig.java
+++ b/src/main/java/com/flex/interpre/global/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package com.flex.interpre.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                )
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .info(info());
+    }
+
+    private Info info(){
+        return new Info()
+                .title("Interpre")
+                .description("2025 Data Venture 공모전")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/flex/interpre/global/dto/ApiResponse.java
+++ b/src/main/java/com/flex/interpre/global/dto/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.flex.interpre.global.dto;
+
+import org.springframework.http.HttpStatus;
+
+public record ApiResponse<T>(
+        int statusCode,
+        String message,
+        T data
+){
+    public static ApiResponse<Void> ok() {
+        return new ApiResponse<>(200, null, null);
+    }
+
+    public static <T> ApiResponse<T> ok(T content) {
+        return new ApiResponse<>(200, null, content);
+    }
+
+    public static <T> ApiResponse<T> error(HttpStatus status, String error) {
+        return new ApiResponse<>(status.value(), error, null);
+    }
+}

--- a/src/main/java/com/flex/interpre/global/exception/ApiException.java
+++ b/src/main/java/com/flex/interpre/global/exception/ApiException.java
@@ -1,0 +1,15 @@
+package com.flex.interpre.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    public ApiException(HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/com/flex/interpre/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/flex/interpre/global/exception/ApiExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.flex.interpre.global.exception;
+
+import com.flex.interpre.global.dto.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    // DTO 유효성 검증 실패 시 (@RequestBody @Valid 등 에서 감지)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> handleValidation(MethodArgumentNotValidException e) {
+        FieldError error = e.getBindingResult().getFieldError();
+//        String field = (error != null) ? error.getField() : "unknown";
+        String message = (error != null && error.getDefaultMessage() != null)
+                ? error.getDefaultMessage() : "잘못된 요청입니다.";
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, message);
+    }
+
+    // 파라미터 검증 실패 시
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ApiResponse<?> handleConstraintViolation(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath() + " " + v.getMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, message);
+    }
+
+    // 권한 요청 실패 시
+    @ExceptionHandler(AccessDeniedException.class)
+    public ApiResponse<Void> AccessDeniedException(AccessDeniedException e){
+        return ApiResponse.error(HttpStatus.FORBIDDEN,"권한이 없습니다.");
+    }
+
+    // 커스텀 예외
+    @ExceptionHandler(ApiException.class)
+    public ApiResponse<?> handleApiException(ApiException e) {
+        return ApiResponse.error(e.getHttpStatus(), e.getMessage());
+    }
+
+    // 모든 예외 fallback
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<?> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+        return ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 오류가 발생했습니다.");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=interpre-server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+spring:
+  datasource:


### PR DESCRIPTION
swagger 관련 의존성 추가 및 config 클래스를 추가했습니다.

`ApiResponse` 공통 응답 DTO를 추가했습니다.
`ApiException` RuntimeException 상속한 커스텀 예외 정의를 정의했습니다.
`ApiExceptionHandler` global 예외 처리 클래스를 추가했습니다.
    - MethodArgumentNotValidException → DTO 검증 실패
    - ConstraintViolationException → 파라미터 검증 실패
    - AccessDeniedException → 권한 부족 (403 반환)
    - ApiException → 커스텀 예외
    - Exception → 기타 모든 예외 (500 반환, 로그 출력)